### PR TITLE
(trivial) Fix Summary component name in example

### DIFF
--- a/example/views/Summary.js
+++ b/example/views/Summary.js
@@ -1,7 +1,7 @@
 import { useFormikWizard } from 'formik-wizard'
 import React from 'react'
 
-function CompanyInfo() {
+function Summary() {
   const { values } = useFormikWizard()
 
   return (
@@ -13,4 +13,4 @@ function CompanyInfo() {
   )
 }
 
-export default CompanyInfo
+export default Summary


### PR DESCRIPTION
The Summary step's view was mistakenly named `CompanyInfo`. It didn't break anything because it was still imported as `Summary` from the other file, but just fixing in case that confused anybody.